### PR TITLE
#163632873 Update domains on Andela Societies for MVP2

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,8 +26,13 @@ const configs = {
   },
   staging_v2: {
     AUTH_API: 'https://api.andela.com/login?redirect_url=',
-    APP_URL: 'https://design-societies.andela.com',
-    API_BASE_URL: 'https://api-design-societies.andela.com/api/v1'
+    APP_URL: 'https://staging-v2-societies.andela.com',
+    API_BASE_URL: 'https://api-staging-v2-societies.andela.com/api/v1'
+  },
+  production_v2: {
+    AUTH_API: 'https://api.andela.com/login?redirect_url=',
+    APP_URL: 'https://societies-v2.andela.com',
+    API_BASE_URL: 'https://societies-api-v2.andela.com/api/v1'
   },
 };
 


### PR DESCRIPTION
##### What does this PR do?
Updates the staging_v2 and production_v2 environment URLs.

##### Description of Task to be completed?
The domain design-societies.andela.com was chosen as the staging_v2 environment URL. To make the domains tailored to the staging_v2 and production_v2 environment names I changed the URLs to staging-v2-societies.andela.com and api-staging-v2-societies.andela.com for the staging_v2 environment and societies-v2.andela.com and societies-api-v2.andela.com for the production_v2 environment. Once our MVP2 is done the main URL societies.andela.com will be mapped to the Kubernetes service that is running the production_v2 environment. This provides the ability for a Blue-Green Deployment environment.

##### Any background context you want to provide?
This P.R. goes hand in hand with [this](https://github.com/andela/bench-products-infrastructure/pull/58)

##### What are the relevant Pivotal Tracker stories?
https://www.pivotaltracker.com/story/show/163632873

##### Questions?
N/A

##### Screenshots?
N/A
