### PR TITLE
Avail userId to fetchUserRole

### DIFF
--- a/src/app/Authentication/components/AuthenticateRoute.js
+++ b/src/app/Authentication/components/AuthenticateRoute.js
@@ -22,7 +22,7 @@ export const Authenticate = ({
           <div className='wrapper'>
             <HeroComponent />
             <div className='main-content'>
-              <SidebarContainer className='sidebar' userId={userInfo.id} />
+              <SidebarContainer className='sidebar' />
               <div className='sub-content'>
                 <NavbarContainer userInfo={userInfo} />
                 <Component {...props} />

--- a/src/app/Sidebar/components/SidebarContainer.js
+++ b/src/app/Sidebar/components/SidebarContainer.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { actions } from '../operations';
 
+import { getUserInfo, getToken } from '../../utils/tokenIsValid';
 import { LogoComponent, NavItemComponent } from '../../common/components/index';
 
 /**
@@ -11,7 +12,6 @@ import { LogoComponent, NavItemComponent } from '../../common/components/index';
  */
 export class SidebarContainer extends Component {
   static defaultProps = {
-    userId: '',
     className: '',
     userRole: {},
     fetchUserRole: null,
@@ -19,7 +19,6 @@ export class SidebarContainer extends Component {
   };
 
   static propTypes = {
-    userId: PropTypes.string,
     userRole: PropTypes.shape({}),
     className: PropTypes.string,
     fetchUserRole: PropTypes.func,
@@ -27,9 +26,11 @@ export class SidebarContainer extends Component {
   };
 
   componentDidMount() {
-    const { userId, fetchUserRole } = this.props;
+    const { fetchUserRole } = this.props;
     // action to get user role
-    fetchUserRole(userId);
+    const token = getToken();
+    const userInfo = getUserInfo(token);
+    fetchUserRole(userInfo.id);
   }
 
   render() {

--- a/src/app/Sidebar/components/tests/SidebarContainer.test.js
+++ b/src/app/Sidebar/components/tests/SidebarContainer.test.js
@@ -4,7 +4,6 @@ import { SidebarContainer } from '../SidebarContainer';
 
 describe('<SidebarContainer />', () => {
   const props = {
-    userId: '',
     className: '',
     userRole: {},
     fetchUserRole: jest.fn(),


### PR DESCRIPTION
##### What does this PR do?
Fixes the bug to avail `userId` at all times to `fetchUserRole `.

